### PR TITLE
fixed NaN value in distanceTo method

### DIFF
--- a/lib/src/utils.dart
+++ b/lib/src/utils.dart
@@ -29,7 +29,7 @@ extension OffsetEx on Offset {
     final len = axisDistanceTo(other);
     final m = sqrt(len.dx * len.dx + len.dy * len.dy);
 
-    return Offset(len.dx / m, len.dy / m);
+    return Offset(m == 0 ? 0 : (len.dx / m), m == 0 ? 0 : (len.dy / m));
   }
 
   Offset rotate(double radians) {


### PR DESCRIPTION
test code is like below
```
    final smoothRatio = 0.65;
    final prev = OffsetPoint(
        dx: 182.1818181818182,
        dy: 345.45454545454544,
        timestamp: 1608169791928);
    final start = OffsetPoint(
        dx: 178.54545454545453, dy: 364.0, timestamp: 1608169791944);
    final end = OffsetPoint(
        dx: 177.45454545454547,
        dy: 368.72727272727275,
        timestamp: 1608169791962);
    final next = OffsetPoint(
        dx: 178.54545454545453, dy: 364.0, timestamp: 1608169791977);

    final cpStart = CubicLine.softCP(
      start,
      previous: prev,
      next: end,
      smoothing: smoothRatio,
    );
    final cpEnd = CubicLine.softCP(
      end,
      previous: start,
      next: next,
      smoothing: smoothRatio,
      reverse: true,
    );
    print('cpStart:${cpStart.dx}, ${cpStart.dx}');
    print('cpEnd:${cpEnd.dx}, ${cpEnd.dx}');

```