### PR TITLE
Added scaleToFill bool in HandSignatureControl.toPicture

### DIFF
--- a/lib/src/signature_control.dart
+++ b/lib/src/signature_control.dart
@@ -1043,17 +1043,23 @@ class HandSignatureControl extends ChangeNotifier {
   }
 
   /// Exports data to [Picture].
-  Picture toPicture(
-      {int width: 512,
-      int height: 256,
-      Color? color,
-      Color? background,
-      double? size,
-      double? maxSize,
-      double? border}) {
-    final data = PathUtil.fill(
-        _arcs, Rect.fromLTRB(0.0, 0.0, width.toDouble(), height.toDouble()),
-        border: border);
+  Picture toPicture({
+    int width: 512,
+    int height: 256,
+    Color? color,
+    Color? background,
+    double? size,
+    double? maxSize,
+    double? border,
+    bool scaleToFill = true,
+  }) {
+    final data = scaleToFill
+        ? PathUtil.fill(
+            _arcs,
+            Rect.fromLTRB(0.0, 0.0, width.toDouble(), height.toDouble()),
+            border: border,
+          )
+        : _arcs;
     final path = CubicPath().._arcs.addAll(data);
 
     params ??= SignaturePaintParams(
@@ -1092,15 +1098,17 @@ class HandSignatureControl extends ChangeNotifier {
   }
 
   /// Exports data to raw image.
-  Future<ByteData?> toImage(
-      {int width: 512,
-      int height: 256,
-      Color? color,
-      Color? background,
-      double? size,
-      double? maxSize,
-      double? border,
-      ImageByteFormat format: ImageByteFormat.png}) async {
+  Future<ByteData?> toImage({
+    int width: 512,
+    int height: 256,
+    Color? color,
+    Color? background,
+    double? size,
+    double? maxSize,
+    double? border,
+    ImageByteFormat format: ImageByteFormat.png,
+    bool scaleToFill = true,
+  }) async {
     final image = await toPicture(
       width: width,
       height: height,
@@ -1109,6 +1117,7 @@ class HandSignatureControl extends ChangeNotifier {
       size: size,
       maxSize: maxSize,
       border: border,
+      scaleToFill: scaleToFill,
     ).toImage(width, height);
 
     return image.toByteData(format: format);


### PR DESCRIPTION
Hello,

I'm using your package and I think it's really nice.
However I'm facing this little issue, where the image produced by the controller is not the same picture drawn.

Example below:

| HandSignaturePainterView | controller.toImage() |
| ------------ | ------------ |
| ![IMG_0159](https://user-images.githubusercontent.com/2032334/143036747-ada89a49-414d-4e3f-8e25-b48e31a7f1e8.PNG) | ![IMG_0158](https://user-images.githubusercontent.com/2032334/143036787-71b4b674-aed0-40e7-a2ff-81712bf082bf.PNG)|
| ![IMG_0157](https://user-images.githubusercontent.com/2032334/143037091-7c408718-c5ae-491a-9922-046394f65196.PNG) | ![IMG_0156](https://user-images.githubusercontent.com/2032334/143037117-73df8aad-29d5-40c9-9590-50556b7ac09e.PNG)|

I inspected the `toImage` code and found that the path is being scaled by a `PathUtil.fill()` method.

While I understand the optimization of trimming whitespace, this scales the path **points** but not its **width**, resulting in a different image.

So I forked your repository and added a `bool scaleToFill` to disable this behavior and obtain the same image as the one shown by `HandSignaturePainterView`.

The bool is also set to `true` by default, so when omitted it keeps the old behavior, and won't result in a breaking change.

I would be awesome if you could accept this pull request and publish the updated package on pub.dev.