### PR TITLE
Feature/scale to fill

### DIFF
--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -18,6 +18,8 @@ ValueNotifier<String?> svg = ValueNotifier<String?>(null);
 
 ValueNotifier<ByteData?> rawImage = ValueNotifier<ByteData?>(null);
 
+ValueNotifier<ByteData?> scaledRawImage = ValueNotifier<ByteData?>(null);
+
 class MyApp extends StatelessWidget {
   bool get scrollTest => false;
 
@@ -68,7 +70,12 @@ class MyApp extends StatelessWidget {
                         Row(
                           children: <Widget>[
                             CupertinoButton(
-                              onPressed: control.clear,
+                              onPressed: () {
+                                control.clear();
+                                svg.value = null;
+                                rawImage.value = null;
+                                scaledRawImage.value = null;
+                              },
                               child: Text('clear'),
                             ),
                             CupertinoButton(
@@ -83,6 +90,13 @@ class MyApp extends StatelessWidget {
                                 rawImage.value = await control.toImage(
                                   color: Colors.blueAccent,
                                   background: Colors.greenAccent,
+                                  scaleToFill: false,
+                                );
+
+                                scaledRawImage.value = await control.toImage(
+                                  color: Colors.blueAccent,
+                                  background: Colors.greenAccent,
+                                  scaleToFill: true,
                                 );
                               },
                               child: Text('export'),
@@ -100,6 +114,7 @@ class MyApp extends StatelessWidget {
                         mainAxisSize: MainAxisSize.min,
                         children: <Widget>[
                           _buildImageView(),
+                          _buildScaledImageView(),
                           _buildSvgView(),
                         ],
                       ),
@@ -125,7 +140,34 @@ class MyApp extends StatelessWidget {
               return Container(
                 color: Colors.red,
                 child: Center(
-                  child: Text('not signed yet (png)'),
+                  child: Text('not signed yet (png)\nscaleToFill: false'),
+                ),
+              );
+            } else {
+              return Padding(
+                padding: EdgeInsets.all(8.0),
+                child: Image.memory(data.buffer.asUint8List()),
+              );
+            }
+          },
+        ),
+      );
+
+  Widget _buildScaledImageView() => Container(
+        width: 192.0,
+        height: 96.0,
+        decoration: BoxDecoration(
+          border: Border.all(),
+          color: Colors.white30,
+        ),
+        child: ValueListenableBuilder<ByteData?>(
+          valueListenable: scaledRawImage,
+          builder: (context, data, child) {
+            if (data == null) {
+              return Container(
+                color: Colors.red,
+                child: Center(
+                  child: Text('not signed yet (png)\nscaleToFill: true'),
                 ),
               );
             } else {

--- a/lib/src/signature_control.dart
+++ b/lib/src/signature_control.dart
@@ -1043,6 +1043,8 @@ class HandSignatureControl extends ChangeNotifier {
   }
 
   /// Exports data to [Picture].
+  ///
+  /// If [scaleToFill] is enabled, the path will be scaled to fill the image bounds, trimming transparent areas outside.
   Picture toPicture({
     int width: 512,
     int height: 256,
@@ -1098,6 +1100,8 @@ class HandSignatureControl extends ChangeNotifier {
   }
 
   /// Exports data to raw image.
+  ///
+  /// If [scaleToFill] is enabled, the path will be scaled to fill the image bounds, trimming transparent areas outside.
   Future<ByteData?> toImage({
     int width: 512,
     int height: 256,

--- a/lib/src/signature_control.dart
+++ b/lib/src/signature_control.dart
@@ -1057,13 +1057,16 @@ class HandSignatureControl extends ChangeNotifier {
     double? border,
     bool scaleToFill = true,
   }) {
+    final pictureRect = Rect.fromLTRB(
+      0.0,
+      0.0,
+      width.toDouble(),
+      height.toDouble(),
+    );
+    final canvasRect = Rect.fromLTRB(0, 0, _areaSize.width, _areaSize.height);
     final data = scaleToFill
-        ? PathUtil.fill(
-            _arcs,
-            Rect.fromLTRB(0.0, 0.0, width.toDouble(), height.toDouble()),
-            border: border,
-          )
-        : _arcs;
+        ? PathUtil.fill(_arcs, pictureRect, border: border)
+        : PathUtil.fill(_arcs, pictureRect, bound: canvasRect, border: border);
     final path = CubicPath().._arcs.addAll(data);
 
     params ??= SignaturePaintParams(

--- a/lib/src/signature_control.dart
+++ b/lib/src/signature_control.dart
@@ -173,8 +173,8 @@ class CubicLine extends Offset {
         end: end.scale(scaleX, scaleY),
         upStartVector: _upStartVector,
         upEndVector: _upEndVector,
-        startSize: startSize,
-        endSize: endSize,
+        startSize: startSize * (scaleX + scaleY) * 0.5,
+        endSize: endSize * (scaleX + scaleY) * 0.5,
       );
 
   @override

--- a/lib/src/signature_control.dart
+++ b/lib/src/signature_control.dart
@@ -404,7 +404,7 @@ class CubicArc extends Offset {
   Offset scale(double scaleX, double scaleY) => CubicArc(
         start: Offset(dx * scaleX, dy * scaleY),
         location: location.scale(scaleX, scaleY),
-        size: size,
+        size: size * (scaleX + scaleY) * 0.5,
       );
 }
 

--- a/lib/src/signature_control.dart
+++ b/lib/src/signature_control.dart
@@ -1043,17 +1043,23 @@ class HandSignatureControl extends ChangeNotifier {
   }
 
   /// Exports data to [Picture].
-  Picture toPicture(
-      {int width: 512,
-      int height: 256,
-      Color? color,
-      Color? background,
-      double? size,
-      double? maxSize,
-      double? border}) {
-    final data = PathUtil.fill(
-        _arcs, Rect.fromLTRB(0.0, 0.0, width.toDouble(), height.toDouble()),
-        border: border);
+  Picture toPicture({
+    int width: 512,
+    int height: 256,
+    Color? color,
+    Color? background,
+    double? size,
+    double? maxSize,
+    double? border,
+    bool scaleToFill = true,
+  }) {
+    final data = scaleToFill
+        ? PathUtil.fill(
+            _arcs,
+            Rect.fromLTRB(0.0, 0.0, width.toDouble(), height.toDouble()),
+            border: border,
+          )
+        : _arcs;
     final path = CubicPath().._arcs.addAll(data);
 
     params ??= SignaturePaintParams(
@@ -1092,15 +1098,17 @@ class HandSignatureControl extends ChangeNotifier {
   }
 
   /// Exports data to raw image.
-  Future<ByteData?> toImage(
-      {int width: 512,
-      int height: 256,
-      Color? color,
-      Color? background,
-      double? size,
-      double? maxSize,
-      double? border,
-      ImageByteFormat format: ImageByteFormat.png}) async {
+  Future<ByteData?> toImage({
+    int width: 512,
+    int height: 256,
+    Color? color,
+    Color? background,
+    double? size,
+    double? maxSize,
+    double? border,
+    ImageByteFormat format: ImageByteFormat.png,
+    bool scaleToFill = true,
+  }) async {
     final image = await toPicture(
       width: width,
       height: height,
@@ -1109,6 +1117,7 @@ class HandSignatureControl extends ChangeNotifier {
       size: size,
       maxSize: maxSize,
       border: border,
+      scaleToFill: scaleToFill,
     ).toImage(width, height);
 
     return image.toByteData(format: format);

--- a/lib/src/signature_control.dart
+++ b/lib/src/signature_control.dart
@@ -666,13 +666,15 @@ class CubicPath {
       return;
     }
 
-    final arcData = PathUtil.scale(_arcs, ratio);
-    _arcs.clear();
-    _arcs.addAll(arcData.cast<CubicArc>());
+    final arcData = PathUtil.scale<CubicArc>(_arcs, ratio);
+    _arcs
+      ..clear()
+      ..addAll(arcData);
 
-    final lineData = PathUtil.scale(_lines, ratio);
-    _lines.clear();
-    _lines.addAll(lineData.cast<CubicLine>());
+    final lineData = PathUtil.scale<CubicLine>(_lines, ratio);
+    _lines
+      ..clear()
+      ..addAll(lineData);
   }
 
   /// Clears all path data-.


### PR DESCRIPTION
Hello RomanBase,

I updated my brach as you suggested.

When the `scaleToFill` boolean is `true` (default behavior) it will behave like before.
When the `scaleToFill` boolean is `false`, it will use the canvas bounds instead of the path bounds, so the transparent pixels outside the path will not be trimmed.

I've also updated the method `CubicArc.scale()` and `CubicLine.scale()` to scale the size of the stroke.
This will prevent the path from becoming thinner when upscaling or thicker when downscaling.

I've also updated the example to show the feature, as you can see in the screenshots below.

![IMG_0163](https://user-images.githubusercontent.com/2032334/144225026-033277d7-8e2b-4f2f-9d08-14bee5274919.png)

![IMG_0162](https://user-images.githubusercontent.com/2032334/144225057-d0404e82-4987-43fa-8d25-ff0d2772895a.png)

I hope everything is ok for the merge request, let me know if anything else is needed!
