### PR TITLE
Added import export functionality

### DIFF
--- a/lib/src/signature_control.dart
+++ b/lib/src/signature_control.dart
@@ -1,3 +1,4 @@
+import 'dart:convert';
 import 'dart:math' as math;
 import 'dart:typed_data';
 import 'dart:ui';
@@ -53,6 +54,14 @@ class OffsetPoint extends Offset {
         dy: offset.dy,
         timestamp: DateTime.now().millisecondsSinceEpoch,
       );
+
+  factory OffsetPoint._import(Map<String, dynamic> map) => OffsetPoint(
+        dx: map['x'],
+        dy: map['y'],
+        timestamp: map['t'],
+      );
+
+  String get _export => '{"x":$dx,"y":$dy,"t":$timestamp}';
 
   /// Returns velocity between this and [other] - previous point.
   double velocityFrom(OffsetPoint other) => timestamp != other.timestamp
@@ -430,13 +439,13 @@ class CubicArc extends Offset {
 /// Combines sequence of points into one Line.
 class CubicPath {
   /// Raw data.
-  final _points = <OffsetPoint>[];
+  final List<OffsetPoint> _points;
 
   /// [CubicLine] representation of path.
-  final _lines = <CubicLine>[];
+  final List<CubicLine> _lines;
 
   /// [CubicArc] representation of path.
-  final _arcs = <CubicArc>[];
+  final List<CubicArc> _arcs;
 
   /// Returns raw data of path.
   List<OffsetPoint> get points => _points;
@@ -458,10 +467,10 @@ class CubicPath {
   bool get isFilled => _lines.isNotEmpty;
 
   /// Unfinished path.
-  Path? _temp;
+  // Path? _temp;
 
   /// Returns currently unfinished part of path.
-  Path? get tempPath => _temp;
+  // Path? get tempPath => _temp;
 
   /// Maximum possible velocity.
   double maxVelocity = 1.0;
@@ -473,14 +482,14 @@ class CubicPath {
   double _currentSize = 0.0;
 
   /// Distance between two control points.
-  final threshold;
+  final double threshold;
 
   /// Ratio of line smoothing.
   /// Don't have impact to performance. Values between 0 - 1.
   /// [0] - no smoothing, no flattening.
   /// [1] - best smoothing, but flattened.
   /// Best results are between: 0.5 - 0.85.
-  final smoothRatio;
+  final double smoothRatio;
 
   /// Checks if this Line is just dot.
   bool get isDot => lines.length == 1 && lines[0].isDot;
@@ -491,7 +500,11 @@ class CubicPath {
   CubicPath({
     this.threshold: 3.0,
     this.smoothRatio: 0.65,
-  });
+  })  : _points = [],
+        _arcs = [],
+        _lines = [];
+
+  String get _export => '[${points.map((p) => p._export).join(',')}]';
 
   /// Adds line to path.
   void _addLine(CubicLine line) {
@@ -547,8 +560,6 @@ class CubicPath {
   void begin(Offset point, {double velocity: 0.0}) {
     _points.add(point is OffsetPoint ? point : OffsetPoint.from(point));
     _currentVelocity = velocity;
-
-    _temp = _dot(point);
   }
 
   /// Alters path with given [point].
@@ -558,21 +569,13 @@ class CubicPath {
     final nextPoint = point is OffsetPoint ? point : OffsetPoint.from(point);
 
     if (_lastPoint == null || _lastPoint!.distanceTo(nextPoint) < threshold) {
-      _temp = _line(_points.last, nextPoint);
-
       return;
     }
 
     _points.add(nextPoint);
     int count = _points.length;
 
-    if (count < 3) {
-      if (count > 1) {
-        _temp = _line(_points[0], _points[1]);
-      }
-
-      return;
-    }
+    if (count < 3) return;
 
     int i = count - 3;
 
@@ -604,8 +607,6 @@ class CubicPath {
     );
 
     _addLine(line);
-
-    _temp = _line(end, next);
   }
 
   /// Ends path at given [point].
@@ -613,8 +614,6 @@ class CubicPath {
     if (point != null) {
       add(point);
     }
-
-    _temp = null;
 
     if (_points.isEmpty) {
       return false;
@@ -653,31 +652,6 @@ class CubicPath {
 
     return true;
   }
-
-  /// Creates [Path] as dot at given [point].
-  Path _dot(Offset point) => Path()
-    ..moveTo(point.dx, point.dy)
-    ..cubicTo(
-      point.dx,
-      point.dy,
-      point.dx,
-      point.dy,
-      point.dx,
-      point.dy,
-    );
-
-  /// Creates [Path] between [start] and [end] points, curve is controlled be [startCp] and [endCp] control points.
-  Path _line(Offset start, Offset end, [Offset? startCp, Offset? endCp]) =>
-      Path()
-        ..moveTo(start.dx, start.dy)
-        ..cubicTo(
-          startCp != null ? startCp.dx : (start.dx + end.dx) * 0.5,
-          startCp != null ? startCp.dy : (start.dy + end.dy) * 0.5,
-          endCp != null ? endCp.dx : (start.dx + end.dx) * 0.5,
-          endCp != null ? endCp.dy : (start.dy + end.dy) * 0.5,
-          end.dx,
-          end.dy,
-        );
 
   /// Sets scale of whole line.
   void setScale(double ratio) {
@@ -723,7 +697,7 @@ class CubicPath {
 /// Also handles export of finished signature.
 class HandSignatureControl extends ChangeNotifier {
   /// List of active paths.
-  final _paths = <CubicPath>[];
+  final List<CubicPath> _paths;
 
   /// List of currently completed lines.
   List<CubicPath> get paths => _paths;
@@ -759,7 +733,7 @@ class HandSignatureControl extends ChangeNotifier {
   List<CubicLine> get lines {
     final list = <CubicLine>[];
 
-    _paths.forEach((data) => list.addAll(data.lines));
+    _paths.forEach((data) => list.addAll(data._lines));
 
     return list;
   }
@@ -793,9 +767,30 @@ class HandSignatureControl extends ChangeNotifier {
     this.threshold: 3.0,
     this.smoothRatio: 0.65,
     this.velocityRange: 2.0,
-  })  : assert(threshold > 0.0),
+  })  : _paths = [],
+        assert(threshold > 0.0),
         assert(smoothRatio > 0.0),
         assert(velocityRange > 0.0);
+
+  factory HandSignatureControl.import(String source) {
+    final data = jsonDecode(source) as Iterable;
+    final control = HandSignatureControl();
+
+    for (var points in data) {
+      final line = List.of(points);
+
+      //start path with first point
+      control.startPath(OffsetPoint._import(line[0]));
+      for (var point in line.skip(1)) {
+        control.alterPath(OffsetPoint._import(point));
+      }
+      control.closePath();
+    }
+
+    return control;
+  }
+
+  String get export => '[${paths.map((p) => p._export).join(',')}]';
 
   /// Starts new line at given [point].
   void startPath(Offset point) {

--- a/lib/src/utils.dart
+++ b/lib/src/utils.dart
@@ -1,5 +1,4 @@
 import 'dart:math';
-import 'dart:ui';
 
 import 'package:flutter/cupertino.dart';
 import 'package:flutter_svg/flutter_svg.dart';


### PR DESCRIPTION
- Saving only OffsetPoints as they're sufficient for reinitialization

### Data Size
I have tested multiple times to check the JSON string's size. On average the SVG export is around 30 kilobytes and the JSON string is about 9 kilobytes.

### Usage Example
```
final control = HandSignatureControl()
[Draw the signature using the UI]
final jsonMap = control.toMap
[Save the jsonMap as you want]
```

On the next launch:
```
final jsonMap  = [load the saved map]
final control = HandSignatureControl.fromMap(jsonMap)
```