### PR TITLE
docs: used "width" and "maxWidth" in example

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,8 +24,8 @@ With **HandSignatureControl** and **HandSignature** is possible to tweak some dr
     final widget = HandSignature(
       control: control,
       color: Colors.blueGrey,
-      strokeWidth: 1.0,
-      maxStrokeWidth: 10.0,
+      width: 1.0,
+      maxWidth: 10.0,
       type: SignatureDrawType.shape,
     );
 ```


### PR DESCRIPTION
The current example used in the README uses `strokeWidth` and `maxStrokeWidth`, these are not members of `HandSignature`. Instead, the new members are `width` and `maxWidth`.


**Additional context**
 https://github.com/RomanBase/hand_signature/blob/5558ad42de1a74183fbddfd3cc297b15f3d2a574/lib/src/signature_view.dart#L15

https://github.com/RomanBase/hand_signature/blob/5558ad42de1a74183fbddfd3cc297b15f3d2a574/lib/src/signature_view.dart#L18