### PR TITLE
Add support for passing doubles in `HandSignatureControl.toSvg`

### DIFF
--- a/lib/src/signature_control.dart
+++ b/lib/src/signature_control.dart
@@ -945,8 +945,8 @@ class HandSignatureControl extends ChangeNotifier {
   /// [type] - data structure.
   String? toSvg({
     SignatureDrawType type = SignatureDrawType.shape,
-    int width = 512,
-    int height = 256,
+    num width = 512,
+    num height = 256,
     double border = 0.0,
     Color? color,
     double? strokeWidth,


### PR DESCRIPTION
- Add support for passing `double` values to `HandSignatureControl.toSvg`

The `int` values are converted to `double` values anyways: https://github.com/RomanBase/hand_signature/blob/32790cb21d42847dd6829f940e50b3cf6adb8d49/lib/src/signature_control.dart#L971-L975